### PR TITLE
Remove dependency on @tldraw/vec implementation of distance calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ import { PerfectCursor } from "perfect-cursors"
 
 const elm = document.getElementById("cursor")
 
-function updateMyCursor(point: number[]) {
+function updateMyCursor(point: [number, number]) {
   elm.style.setProperty("transform", `translate(${point[0]}px, ${point[1]}px)`)
 }
 
@@ -104,8 +104,8 @@ To use the library in React, create a React hook called `usePerfectCursor`.
 import { PerfectCursor } from "perfect-cursors"
 
 export function usePerfectCursor(
-  cb: (point: number[]) => void,
-  point?: number[]
+  cb: (point: [number, number]) => void,
+  point?: [number, number]
 ) {
   const [pc] = React.useState(() => new PerfectCursor(cb))
 
@@ -116,7 +116,7 @@ export function usePerfectCursor(
   }, [pc])
 
   const onPointChange = React.useCallback(
-    (point: number[]) => pc.addPoint(point),
+    (point: [number, number]) => pc.addPoint(point),
     [pc]
   )
 
@@ -132,10 +132,10 @@ And then a Cursor component that looks something like this:
 import * as React from "react"
 import { usePerfectCursor } from "../hooks/usePerfectCursors"
 
-export function Cursor({ point }: { point: number[] }) {
+export function Cursor({ point }: { point: [number, number] }) {
   const rCursor = React.useRef<SVGSVGElement>(null)
 
-  const animateCursor = React.useCallback((point: number[]) => {
+  const animateCursor = React.useCallback((point: [number, number]) => {
     const elm = rCursor.current
     if (!elm) return
     elm.style.setProperty(

--- a/example/src/app.tsx
+++ b/example/src/app.tsx
@@ -4,7 +4,7 @@ import throttle from 'lodash.throttle'
 import { INTERVAL_DURATION } from './constants'
 
 export default function App() {
-  const [point, setPoint] = React.useState<number[]>()
+  const [point, setPoint] = React.useState<[number, number]>()
   const [duration, setDuration] = React.useState<number>(INTERVAL_DURATION)
 
   const onPointerMove = React.useCallback(

--- a/example/src/components/Cursor.tsx
+++ b/example/src/components/Cursor.tsx
@@ -2,11 +2,11 @@ import { PerfectCursor } from 'perfect-cursors'
 import * as React from 'react'
 import { usePerfectCursor } from '../hooks/usePerfectCursors'
 
-export function Cursor({ point, maxInterval }: { point: number[]; maxInterval: number }) {
+export function Cursor({ point, maxInterval }: { point: [number, number]; maxInterval: number }) {
   const rCursor = React.useRef<SVGSVGElement>(null)
 
   // 1. perfect-cursors
-  const animateCursor = React.useCallback((point: number[]) => {
+  const animateCursor = React.useCallback((point: [number, number]) => {
     const elm = rCursor.current
     if (!elm) return
     elm.style.setProperty('transform', `translate(${point[0]}px, ${point[1]}px)`)
@@ -23,7 +23,7 @@ export function Cursor({ point, maxInterval }: { point: number[]; maxInterval: n
     PerfectCursor.MAX_INTERVAL = maxInterval
   }, [maxInterval])
 
-  const onPointChange = React.useCallback((point: number[]) => pc.addPoint(point), [pc])
+  const onPointChange = React.useCallback((point: [number, number]) => pc.addPoint(point), [pc])
 
   React.useLayoutEffect(() => onPointChange(point), [onPointChange, point])
 
@@ -38,8 +38,8 @@ export function Cursor({ point, maxInterval }: { point: number[]; maxInterval: n
 
   // 3. Animating between points
   // const rTimeout = React.useRef<any>()
-  // const rPrevPoint = React.useRef<number[]>(point)
-  // const rNextPoint = React.useRef<number[]>(point)
+  // const rPrevPoint = React.useRef<[number, number]>(point)
+  // const rNextPoint = React.useRef<[number, number]>(point)
   // const rPrevStart = React.useRef<number>(performance.now())
   // const rNextStart = React.useRef<number>(performance.now())
   // const rDuration = React.useRef<number>(0)

--- a/example/src/hooks/usePerfectCursors.ts
+++ b/example/src/hooks/usePerfectCursors.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { PerfectCursor } from 'perfect-cursors'
 
-export function usePerfectCursor(cb: (point: number[]) => void, point?: number[]) {
+export function usePerfectCursor(cb: (point: [number, number]) => void, point?: [number, number]) {
   const [pc] = React.useState(() => new PerfectCursor(cb))
 
   React.useLayoutEffect(() => {
@@ -9,7 +9,7 @@ export function usePerfectCursor(cb: (point: number[]) => void, point?: number[]
     return () => pc.dispose()
   }, [pc])
 
-  const onPointChange = React.useCallback((point: number[]) => pc.addPoint(point), [pc])
+  const onPointChange = React.useCallback((point: [number, number]) => pc.addPoint(point), [pc])
 
   return onPointChange
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,5 @@
     "tslib": "^2.3.0",
     "typedoc": "^0.22.3",
     "typescript": "^4.5.2"
-  },
-  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@swc-node/jest": "^1.3.3",
-    "@tldraw/vec": "^1.4.3",
     "@types/jest": "^27.0.2",
     "@types/node": "^15.0.1",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
@@ -43,5 +42,6 @@
     "tslib": "^2.3.0",
     "typedoc": "^0.22.3",
     "typescript": "^4.5.2"
-  }
+  },
+  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/perfect-cursors/README.md
+++ b/perfect-cursors/README.md
@@ -73,7 +73,7 @@ import { PerfectCursor } from 'perfect-cursors'
 
 const elm = document.getElementById('cursor')
 
-function updateMyCursor(point: number[]) {
+function updateMyCursor(point: [number, number]) {
   elm.style.setProperty('transform', `translate(${point[0]}px, ${point[1]}px)`)
 }
 
@@ -103,7 +103,7 @@ To use the library in React, create a React hook called `usePerfectCursor`.
 
 import { PerfectCursor } from 'perfect-cursors'
 
-export function usePerfectCursor(cb: (point: number[]) => void, point?: number[]) {
+export function usePerfectCursor(cb: (point: [number, number]) => void, point?: [number, number]) {
   const [pc] = React.useState(() => new PerfectCursor(cb))
 
   React.useLayoutEffect(() => {
@@ -112,7 +112,7 @@ export function usePerfectCursor(cb: (point: number[]) => void, point?: number[]
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pc])
 
-  const onPointChange = React.useCallback((point: number[]) => pc.addPoint(point), [pc])
+  const onPointChange = React.useCallback((point: [number, number]) => pc.addPoint(point), [pc])
 
   return onPointChange
 }
@@ -126,10 +126,10 @@ And then a Cursor component that looks something like this:
 import * as React from 'react'
 import { usePerfectCursor } from '../hooks/usePerfectCursors'
 
-export function Cursor({ point }: { point: number[] }) {
+export function Cursor({ point }: { point: [number, number] }) {
   const rCursor = React.useRef<SVGSVGElement>(null)
 
-  const animateCursor = React.useCallback((point: number[]) => {
+  const animateCursor = React.useCallback((point: [number, number]) => {
     const elm = rCursor.current
     if (!elm) return
     elm.style.setProperty('transform', `translate(${point[0]}px, ${point[1]}px)`)

--- a/perfect-cursors/package.json
+++ b/perfect-cursors/package.json
@@ -45,7 +45,5 @@
     "typedoc": "^0.22.3",
     "typescript": "^4.5.2"
   },
-  "dependencies": {
-    "@tldraw/vec": "^1.4.3"
-  }
+  "dependencies": {}
 }

--- a/perfect-cursors/src/perfect-cursor.ts
+++ b/perfect-cursors/src/perfect-cursor.ts
@@ -1,11 +1,11 @@
-import { Vec } from '@tldraw/vec'
+import { dist, type Point2D } from './point'
 import { Spline } from './spline'
 
 type AnimationState = 'stopped' | 'idle' | 'animating'
 
 type Animation = {
-  from: number[]
-  to: number[]
+  from: Point2D
+  to: Point2D
   start: number
   duration: number
 }
@@ -15,17 +15,17 @@ export class PerfectCursor {
   queue: Animation[] = []
   timestamp = performance.now()
   lastRequestId = 0
-  timeoutId: any = 0
-  prevPoint?: number[]
+  timeoutId: ReturnType<typeof setTimeout> | null = null
+  prevPoint?: Point2D
   spline = new Spline()
-  cb: (point: number[]) => void
+  cb: (point: Point2D) => void
 
-  constructor(cb: (point: number[]) => void) {
+  constructor(cb: (point: Point2D) => void) {
     this.cb = cb
   }
 
-  addPoint = (point: number[]) => {
-    clearTimeout(this.timeoutId)
+  addPoint = (point: Point2D) => {
+    if (this.timeoutId) clearTimeout(this.timeoutId)
     const now = performance.now()
     const duration = Math.min(now - this.timestamp, PerfectCursor.MAX_INTERVAL)
     if (!this.prevPoint) {
@@ -37,7 +37,7 @@ export class PerfectCursor {
       return
     }
     if (this.state === 'stopped') {
-      if (Vec.dist(this.prevPoint, point) < 4) {
+      if (dist(this.prevPoint, point) < 4) {
         this.cb(point)
         return
       }
@@ -106,6 +106,6 @@ export class PerfectCursor {
   static MAX_INTERVAL = 300
 
   dispose = () => {
-    clearTimeout(this.timeoutId)
+    if (this.timeoutId) clearTimeout(this.timeoutId)
   }
 }

--- a/perfect-cursors/src/point.ts
+++ b/perfect-cursors/src/point.ts
@@ -1,5 +1,5 @@
-export type Point2D = [number, number];
+export type Point2D = [number, number]
 
 export function dist(a: Point2D, b: Point2D): number {
-    return Math.hypot(a[1] - b[1], a[0] - b[0]);
+  return Math.hypot(a[1] - b[1], a[0] - b[0])
 }

--- a/perfect-cursors/src/point.ts
+++ b/perfect-cursors/src/point.ts
@@ -1,0 +1,5 @@
+export type Point2D = [number, number];
+
+export function dist(a: Point2D, b: Point2D): number {
+    return Math.hypot(a[1] - b[1], a[0] - b[0]);
+}

--- a/perfect-cursors/src/spline.ts
+++ b/perfect-cursors/src/spline.ts
@@ -1,23 +1,23 @@
-import { Vec } from '@tldraw/vec'
+import { dist, type Point2D } from './point'
 
 export class Spline {
-  points: number[][] = []
+  points: Point2D[] = []
 
   lengths: number[] = []
 
   totalLength = 0
 
-  private prev?: number[]
+  private prev?: Point2D
 
-  constructor(points: number[][] = []) {
+  constructor(points: Point2D[] = []) {
     this.points = points
-    this.lengths = points.map((point, i, arr) => (i === 0 ? 0 : Vec.dist(point, arr[i - 1])))
+    this.lengths = points.map((point, i, arr) => (i === 0 ? 0 : dist(point, arr[i - 1])))
     this.totalLength = this.lengths.reduce((acc, cur) => acc + cur, 0)
   }
 
-  addPoint = (point: number[]) => {
+  addPoint = (point: Point2D) => {
     if (this.prev) {
-      const length = Vec.dist(this.prev, point)
+      const length = dist(this.prev, point)
       this.lengths.push(length)
       this.totalLength += length
       this.points.push(point)
@@ -30,7 +30,7 @@ export class Spline {
     this.totalLength = 0
   }
 
-  getSplinePoint = (rt: number): number[] => {
+  getSplinePoint = (rt: number): Point2D => {
     const { points } = this
     const l = points.length - 1,
       d = Math.trunc(rt),
@@ -45,9 +45,13 @@ export class Spline {
       q2 = 3 * ttt - 5 * tt + 2,
       q3 = -3 * ttt + 4 * tt + t,
       q4 = ttt - tt
+    const [p0x, p0y] = points[p0],
+      [p1x, p1y] = points[p1],
+      [p2x, p2y] = points[p2],
+      [p3x, p3y] = points[p3]
     return [
-      (points[p0][0] * q1 + points[p1][0] * q2 + points[p2][0] * q3 + points[p3][0] * q4) / 2,
-      (points[p0][1] * q1 + points[p1][1] * q2 + points[p2][1] * q3 + points[p3][1] * q4) / 2,
+      (p0x * q1 + p1x * q2 + p2x * q3 + p3x * q4) / 2,
+      (p0y * q1 + p1y * q2 + p2y * q3 + p3y * q4) / 2,
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,11 +1591,6 @@
     "@swc/core-win32-ia32-msvc" "1.2.127"
     "@swc/core-win32-x64-msvc" "1.2.127"
 
-"@tldraw/vec@^1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@tldraw/vec/-/vec-1.4.3.tgz#c1460da019063b8eb9c62d715c61dff44dd23b02"
-  integrity sha512-p7Nu9OWqorQ+nWPlvkN6Zn1oDbRgr4sheLzRif/+xB7BzMQFJh1T8syX6Jj/S88GPvn5PwZgYUKMnMFvvL5t/w==
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
Sorry about the somewhat bigger PR. I've gone a bit overboard and refactored the types a bit. This way bugs could be caught earlier. The current implementation only works with 2-dimensional points but allows arrays of any length. 

@steveruizok if you don't like these type changes I'll extract the `dist` function into a smaller PR.

Closes #1 